### PR TITLE
Feat/#73 coordinates bar

### DIFF
--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
@@ -379,7 +379,11 @@ class PluginCommands(private val main: PluginMain) : CommandExecutor {
                 player.level = 0
             }
             player.inventory.addItem(ItemStack(Material.COMPASS, 1))
+            Bukkit.getScheduler().scheduleSyncRepeatingTask(main, {
+                main.taskManager.updateActionBar(player, main.hunters)
+            }, 10L, 20L)
         }
+
     }
 
     private fun startState(player: Player) {
@@ -404,6 +408,9 @@ class PluginCommands(private val main: PluginMain) : CommandExecutor {
                 player.exp = 0f
                 player.level = 0
             }
+            Bukkit.getScheduler().scheduleSyncRepeatingTask(main, {
+                main.taskManager.updateActionBar(player, main.runners)
+            }, 0L, 20L)
         }
     }
 

--- a/MinecraftManhunt/src/main/java/manhunt_plus/TaskManager.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/TaskManager.kt
@@ -1,15 +1,20 @@
 package manhunt_plus
 
+import net.md_5.bungee.api.ChatMessageType
+import net.md_5.bungee.api.chat.TextComponent
 import org.bukkit.Bukkit
+import org.bukkit.ChatColor
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.CreatureSpawner
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.EntityType
+import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.meta.CompassMeta
 import org.bukkit.potion.PotionEffectType
 import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Handle running tasks
@@ -72,6 +77,48 @@ class TaskManager(private val main: PluginMain) {
             player.player!!.addPotionEffect(PotionEffectType.FAST_DIGGING.createEffect(Int.MAX_VALUE, 3))
         }
     } //
+
+    /**
+     * Displays the coordinates of the closest teammate in the action bar
+     *
+     * @param player the player receiving the coordinates
+     * @param teammates the teammates
+     */
+    fun updateActionBar(player: Player, teammates: MutableList<Player> ) {
+        val playerX = player.location.x
+        val playerZ = player.location.z
+
+        val teammateLocation = closestTeammateCoords(playerX, playerZ, teammates)
+
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent(
+            """ ${ChatColor.BOLD} ${ChatColor.RED} x: ${teammateLocation?.x?.roundToInt()}, y: ${teammateLocation?.y?.roundToInt()}, z: ${teammateLocation?.z?.roundToInt()}"""));
+    }
+
+    /**
+     * Returns the location to the closest teammate
+     *
+     * @param playerX the player's X coordinate
+     * @param playerZ the player's Z coordinate
+     * @param teammates the teammates of that player
+     * @return the closest location
+     */
+    private fun closestTeammateCoords(playerX: Double, playerZ: Double, teammates: MutableList<Player>): Location? {
+        var closestLocation: Location? = null;
+        var closestDistance: Double = Double.MAX_VALUE
+        for (player in teammates){
+
+            val xAxisDifference = player.location.x - playerX
+            val zAxisDifference = player.location.z - playerZ
+
+            val totalDifference = xAxisDifference + zAxisDifference
+            if (totalDifference < closestDistance && totalDifference != 0.0){
+                closestLocation = player.location
+                closestDistance = totalDifference
+            }
+        }
+
+        return closestLocation
+    }
 
     //    public void showGlow(){
     //        for (Player player : main.runners)

--- a/MinecraftManhunt/src/main/java/manhunt_plus/TaskManager.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/TaskManager.kt
@@ -89,7 +89,6 @@ class TaskManager(private val main: PluginMain) {
         val playerZ = player.location.z
 
         val teammateLocation = closestTeammateCoords(playerX, playerZ, teammates)
-
         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent(
             """ ${ChatColor.BOLD} ${ChatColor.RED} x: ${teammateLocation?.x?.roundToInt()}, y: ${teammateLocation?.y?.roundToInt()}, z: ${teammateLocation?.z?.roundToInt()}"""));
     }
@@ -100,11 +99,16 @@ class TaskManager(private val main: PluginMain) {
      * @param playerX the player's X coordinate
      * @param playerZ the player's Z coordinate
      * @param teammates the teammates of that player
-     * @return the closest location
+     * @return the location of the closest teammate, or the world's spawn-point if the player has no teammates
      */
     private fun closestTeammateCoords(playerX: Double, playerZ: Double, teammates: MutableList<Player>): Location? {
         var closestLocation: Location? = null;
         var closestDistance: Double = Double.MAX_VALUE
+        // If the player has no teammates
+        if (teammates.size == 1){
+            return main.world?.spawnLocation
+        }
+        // Find the closest teammate
         for (player in teammates){
 
             val xAxisDifference = player.location.x - playerX


### PR DESCRIPTION
Added an action bar (above the health bar) which displays the coordinates of the nearest teammate. If a player has no teammates, the spawn point of the world is displayed

Closes: #73 