### PR TITLE
Feat/#72 speedrunner compass

### DIFF
--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
@@ -389,7 +389,6 @@ class PluginCommands(private val main: PluginMain) : CommandExecutor {
             player.addPotionEffect(PotionEffect(PotionEffectType.BLINDNESS, 20 * headStartDuration, 3))
             player.addPotionEffect(PotionEffect(PotionEffectType.SLOW_DIGGING, 20 * headStartDuration, 10))
             startState(player)
-            player.inventory.addItem(ItemStack(Material.COMPASS, 1))
             Bukkit.getScheduler().scheduleSyncRepeatingTask(main, {
                 main.taskManager.updateActionBar(player, main.hunters)
             }, 10L, 20L)
@@ -406,6 +405,7 @@ class PluginCommands(private val main: PluginMain) : CommandExecutor {
         player.inventory.clear()
         player.exp = 0f
         player.level = 0
+        player.inventory.addItem(ItemStack(Material.COMPASS, 1))
     }
 
     /**

--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
@@ -48,10 +48,6 @@ class PluginListener(var main: PluginMain) : Listener {
                 }
                 return
             }
-            if (main.runners.contains(player) && !main.debugMode) {
-                player.sendMessage("Speedrunners cannot use the compass!")
-                return
-            }
             if (main.commands.compassTask == -1) {
                 player.sendMessage("Start the Manhunt game before using the compass!")
                 return


### PR DESCRIPTION
Speedrunners can now use compasses, and are given one when the game starts. They can find their teammates with their compasses, just like hunters.

Closes: #72 