### PR TITLE
Feat/#91 balancing issues

### DIFF
--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginCommands.kt
@@ -15,6 +15,9 @@ import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
+import org.bukkit.inventory.meta.PotionMeta
+import org.bukkit.potion.PotionData
+import org.bukkit.potion.PotionType
 
 /**
  * The Commands used in Manhunt
@@ -416,11 +419,21 @@ class PluginCommands(private val main: PluginMain) : CommandExecutor {
         for (player in main.runners) {
             startState(player)
             player.foodLevel = 20
-            player.addPotionEffect(PotionEffect(PotionEffectType.SPEED, 400, 1))
+            player.addPotionEffect(PotionEffect(PotionEffectType.SPEED, 1200, 1))
             Bukkit.getScheduler().scheduleSyncRepeatingTask(main, {
                 main.taskManager.updateActionBar(player, main.runners)
             }, 0L, 20L)
+            val speedPotion = createSpeedPotion()
+            player.inventory.addItem(speedPotion)
         }
+    }
+
+    private fun createSpeedPotion(): ItemStack {
+        val speedPotion = ItemStack(Material.POTION, 1)
+        val meta = speedPotion.itemMeta as PotionMeta?
+        meta?.basePotionData = PotionData(PotionType.SPEED)
+        speedPotion.itemMeta = meta
+        return speedPotion
     }
 
     /**

--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
@@ -1,10 +1,8 @@
 package manhunt_plus
 
 import manhunt_plus.chest_generation.createChest
-import manhunt_plus.chest_generation.generateChestItems
 import manhunt_plus.game_state.AdvancementValue
 import org.bukkit.*
-import org.bukkit.block.Chest
 import org.bukkit.entity.*
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -397,6 +395,13 @@ class PluginListener(var main: PluginMain) : Listener {
             }
         }
         if (main.commands.isCutClean) {
+            // If player is a hunter, run probability for no cut clean
+            if (main.getTeam(event.player) == main.hunters){
+                if (cutCleanCalculator()){
+                    return
+                }
+            }
+            // Handle cut clean
             val blockBroken = event.block
             val world = blockBroken.world
             val location = blockBroken.location
@@ -434,6 +439,16 @@ class PluginListener(var main: PluginMain) : Listener {
             }
         }
 
+    }
+
+    private fun cutCleanCalculator(): Boolean {
+        return if(main.gameState < 3.7){
+            Math.random() < 0.69
+        } else if (main.gameState < 5){
+            Math.random() < 0.2
+        } else{
+            Math.random() < 0.1
+        }
     }
 
 

--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
@@ -133,7 +133,7 @@ class PluginListener(var main: PluginMain) : Listener {
                         TaskManager.generateSpawner()
                         spawnersGenerated++
                     }
-                }, 12000L, 3600L)
+                }, 8400L, 3600L)
             }
         }
         // If overworld to end

--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginListener.kt
@@ -385,7 +385,12 @@ class PluginListener(var main: PluginMain) : Listener {
 //        }
         // If chest generate is on
         if (main.commands.chestGenerate) { // THIS MUST BE BEFORE CUT CLEAN CHECK
-            val numberGenerated = random.nextInt(550)
+            var numberGenerated : Int = 0
+            if (main.getTeam(event.player) == main.hunters)
+                numberGenerated = random.nextInt(625)
+            else if (main.getTeam(event.player) == main.runners)
+                numberGenerated = random.nextInt(525)
+
             if (numberGenerated == 69) {
                 val blockBrokenLocation = event.block.location
                 createChest(blockBrokenLocation, event, event.player.world)

--- a/MinecraftManhunt/src/main/java/manhunt_plus/PluginMain.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/PluginMain.kt
@@ -84,4 +84,18 @@ class PluginMain : JavaPlugin() {
         onDisable(this)
     }
 
+    fun getTeam(player: Player): List<Player>{
+        return when (player) {
+            in runners -> {
+                runners
+            }
+            in hunters -> {
+                hunters
+            }
+            else -> {
+                spectators
+            }
+        }
+    }
+
 }

--- a/MinecraftManhunt/src/main/java/manhunt_plus/chest_generation/ItemGenerator.kt
+++ b/MinecraftManhunt/src/main/java/manhunt_plus/chest_generation/ItemGenerator.kt
@@ -54,20 +54,22 @@ class ItemGenerator {
     )
     // Chest tiers
     private val chestTierOne = listOf(
-            ChestItem(Material.DIAMOND_BOOTS, bootsEnchants),
-            ChestItem(Material.DIAMOND_LEGGINGS, mainArmorEnchants),
-            ChestItem(Material.DIAMOND_CHESTPLATE, mainArmorEnchants),
-            ChestItem(Material.DIAMOND_HELMET, helmetEnchants),
-            ChestItem(Material.DIAMOND_PICKAXE, pickaxeEnchantments),
-            ChestItem(Material.DIAMOND, random.nextInt(3) + 1),
-            ChestItem(Material.DIAMOND_SWORD, swordEnchants),
-            ChestItem(Material.ENDER_PEARL, random.nextInt(3) + 3),
-            ChestItem(true),
-            ChestItem(Material.IRON_CHESTPLATE, mainArmorEnchants),
-            ChestItem(Material.IRON_LEGGINGS, mainArmorEnchants),
-            ChestItem(Material.IRON_BOOTS, bootsEnchants),
-            ChestItem(Material.IRON_HELMET, helmetEnchants),
-            ChestItem(Material.BOOKSHELF,6)
+        ChestItem(Material.DIAMOND_BOOTS, bootsEnchants),
+        ChestItem(Material.DIAMOND_LEGGINGS, mainArmorEnchants),
+        ChestItem(Material.DIAMOND_CHESTPLATE, mainArmorEnchants),
+        ChestItem(Material.DIAMOND_HELMET, helmetEnchants),
+        ChestItem(Material.DIAMOND_PICKAXE, pickaxeEnchantments),
+        ChestItem(Material.DIAMOND, random.nextInt(3) + 1),
+        ChestItem(Material.DIAMOND_SWORD, swordEnchants),
+        ChestItem(Material.ENDER_PEARL, random.nextInt(3) + 3),
+        ChestItem(true),
+        ChestItem(Material.IRON_CHESTPLATE, mainArmorEnchants),
+        ChestItem(Material.IRON_LEGGINGS, mainArmorEnchants),
+        ChestItem(Material.IRON_BOOTS, bootsEnchants),
+        ChestItem(Material.IRON_HELMET, helmetEnchants),
+        ChestItem(Material.BOOKSHELF,6),
+        ChestItem(Material.BLAZE_ROD,3)
+
     )
     private val chestTierTwo = listOf(
         ChestItem(Material.DIAMOND_BOOTS, 1),
@@ -84,8 +86,11 @@ class ItemGenerator {
         ChestItem(Material.IRON_BOOTS, bootsEnchants),
         ChestItem(Material.IRON_HELMET, helmetEnchants),
         ChestItem(Material.BOOK,12),
-        ChestItem(Material.BOOKSHELF,4)
-    )
+        ChestItem(Material.BOOKSHELF,4),
+        ChestItem(Material.BLAZE_ROD,random.nextInt(3)+1),
+        ChestItem(Material.GOLD_BLOCK, random.nextInt(2) + 2),
+
+        )
     private val chestTierThree = listOf(
         ChestItem(Material.GOLDEN_APPLE, 1),
         ChestItem(Material.IRON_INGOT, random.nextInt(13) + 1),
@@ -97,8 +102,10 @@ class ItemGenerator {
         ChestItem(Material.BUCKET, 1),
         ChestItem(Material.OBSIDIAN, 3),
         ChestItem(Material.BOOK,6),
-        ChestItem(Material.BOOKSHELF,2)
-    )
+        ChestItem(Material.BOOKSHELF,2),
+        ChestItem(Material.BLAZE_SPAWN_EGG,random.nextInt(3)+1),
+        ChestItem(Material.PIGLIN_SPAWN_EGG, 3),
+        )
     private val chestTierFour = listOf(
         ChestItem(Material.SHULKER_BOX, 1),
         ChestItem(Material.COOKED_BEEF, random.nextInt(10) + 10),
@@ -110,7 +117,10 @@ class ItemGenerator {
         ChestItem(Material.FEATHER, 7),
         ChestItem(Material.FLINT, 3),
         ChestItem(Material.BOOK,3),
-        ChestItem(Material.ENDER_PEARL, random.nextInt(2) + 1)
+        ChestItem(Material.ENDER_PEARL, random.nextInt(2) + 1),
+        ChestItem(Material.BLAZE_SPAWN_EGG,2),
+        ChestItem(Material.PIGLIN_SPAWN_EGG, 1),
+
         )
     private val chestTierFive = listOf(
         ChestItem(Material.OAK_PLANKS, 32),


### PR DESCRIPTION
After 8/8 rounds of this plugin have been won by the hunter's, it was time for the runners to receive a buff. These changes have been made:

- Decrease chest spawning for hunters to 1/625 from 1/550
- Increased chest spawning for runners to 1/525 from 1/550
- Cut clean probability for hunters, lower gameState = lower probability (minimum 30%, maximum 90%)
- Rework chest loot: #61
   - Blaze rods/spawn eggs are added, and slightly increased the chance of getting golden blocks
- Runner's are given 1 speed potion at the start of the game to use whenever they want
- Starting speed boost increased from 20 seconds to 60 seconds
- Blaze spawner in the nether after 7 minutes, up from 10

Closes: #61, #91 